### PR TITLE
Add requirements for local RAG demo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+streamlit
+beautifulsoup4
+python-dotenv
+requests
+langchain
+langchain-community
+langchain-text-splitters
+langchain-ollama
+langchain-core
+langgraph
+pypdf
+unstructured
+tiktoken


### PR DESCRIPTION
## Summary
- Add `requirements.txt` capturing dependencies for the Streamlit-based local RAG demo

## Testing
- `python -m py_compile agentic_rag_local.py` *(fails: f-string expression part cannot include a backslash)*
- `python -m py_compile agentic_rag.py`


------
https://chatgpt.com/codex/tasks/task_e_688f51e3ca348327b1b18214d2b1f16e